### PR TITLE
Reduce EventFlushIntervalMS to 5s

### DIFF
--- a/devcycle.go
+++ b/devcycle.go
@@ -19,7 +19,7 @@ func initalizeDevCycle() *devcycle.Client {
 	options := devcycle.Options{
 		EnableEdgeDB:                 false,
 		EnableCloudBucketing:         false,
-		EventFlushIntervalMS:         30 * time.Second,
+		EventFlushIntervalMS:         5 * time.Second,
 		ConfigPollingIntervalMS:      5 * time.Second,
 		RequestTimeout:               30 * time.Second,
 		DisableAutomaticEventLogging: false,


### PR DESCRIPTION
Reduce the event flush interval so that the evaluation events will be received by the dashboard sooner